### PR TITLE
sortではなくsort_byを使ってパフォーマンスを改善する

### DIFF
--- a/generate_ignorelist/lib/nurikabe/generate_ignorelist/command.rb
+++ b/generate_ignorelist/lib/nurikabe/generate_ignorelist/command.rb
@@ -25,7 +25,7 @@ module Nurikabe
           YAML
             .safe_load(file, symbolize_names: true)
             .flat_map { |group| group[:enabled] ? group[:urls] : [] }
-            .sort { |a, b| a.delete_prefix('*.') <=> b.delete_prefix('*.') }
+            .sort_by { |v| v.delete_prefix('*.') }
             .uniq
             .join(@separator)
         end


### PR DESCRIPTION
sortを使うと比較のたびに`delete_prefix`が実行される。
sort_byを使えば要素数回だけ`delete_prefix`が実行される。