### PR TITLE
proxy_pac: Rack v3.0 を使う

### DIFF
--- a/proxy_pac/Gemfile
+++ b/proxy_pac/Gemfile
@@ -6,3 +6,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'foreman'
 gem 'rack'
+gem 'rackup'

--- a/proxy_pac/Gemfile.lock
+++ b/proxy_pac/Gemfile.lock
@@ -2,7 +2,11 @@ GEM
   remote: https://rubygems.org/
   specs:
     foreman (0.87.2)
-    rack (2.2.3)
+    rack (3.0.6)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -10,6 +14,7 @@ PLATFORMS
 DEPENDENCIES
   foreman
   rack
+  rackup
 
 BUNDLED WITH
-   2.1.4
+   2.4.6


### PR DESCRIPTION
`rackup` は Rack gem から分離されたので、別途依存関係に追加する
- https://github.com/rack/rack/blob/main/CHANGELOG.md#300beta1---2022-08-08